### PR TITLE
Trait-based mechanism to share input/output code among state types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ serde_yaml = "0.8.17"
 clap = "2.33.3"
 nom = "6.1.2"
 thiserror = "1.0.24"
-
+enum_dispatch = "0.3.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ serde_yaml = "0.8.17"
 clap = "2.33.3"
 nom = "6.1.2"
 thiserror = "1.0.24"
-enum_dispatch = "0.3.5"
+

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -2,11 +2,6 @@ use reference_path::ReferencePath;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StateIoError {
-    PathFailure,
-}
-
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Error {
     pub cause: String,


### PR DESCRIPTION
This introduces the `StateIo` trait which provides default implementations for IO processing methods such as applying InputPath and ResultPath. It also provides defaults for the actual values to use for those paths. Combined with one slightly tedious impl for `State` that delegates every method to the enum variant structs, this streamline the code for doing IO.